### PR TITLE
Use correct filename case for keywords.txt

### DIFF
--- a/Keywords.txt
+++ b/Keywords.txt
@@ -1,1 +1,0 @@
-MaxSonar

--- a/keywords.txt
+++ b/keywords.txt
@@ -1,0 +1,1 @@
+MaxSonar


### PR DESCRIPTION
Use of filename case other than exactly keywords.txt causes the file to not be recognized by the Arduino IDE on a filename case-sensitive OS such as Linux.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords